### PR TITLE
Add backchannel bind address to config.

### DIFF
--- a/Tutkain.sublime-settings
+++ b/Tutkain.sublime-settings
@@ -50,7 +50,9 @@
       // NOTE: If you use a fixed port number, you can only open a single
       // connection from Tutkain to a socket REPL server. This is because
       // Tutkain currently uses one backchannel per REPL connection.
-      "port": 0
+      "port": 0,
+      // Bind address for backchannel.
+      "bind_address": "localhost"
     },
   }
 }

--- a/clojure/src/tutkain/backchannel.clj
+++ b/clojure/src/tutkain/backchannel.clj
@@ -94,13 +94,14 @@
   To add a new op, implement the tutkain.backchannel/handle multimethod.
 
   Options:
-    :port    The TCP port the backchannel listens on.
+    :port         The TCP port the backchannel listens on.
+    :bind-address The TCP bind address.
 
   Other options are subject to change."
-  [{:keys [port xform-in xform-out]
-    :or {port 0 xform-in identity xform-out identity}}]
+  [{:keys [port bind-address xform-in xform-out]
+    :or {port 0 bind-address "localhost" xform-in identity xform-out identity}}]
   (let [socket (ServerSocketChannel/open)
-        address (InetSocketAddress. "localhost" port)
+        address (InetSocketAddress. ^String bind-address port)
         lock (Object.)]
     (.bind socket address)
     (let [thread (Thread.

--- a/package.py
+++ b/package.py
@@ -511,7 +511,8 @@ class TutkainConnectCommand(WindowCommand):
             else:
                 client = JVMClient(
                     source_root(), host, int(port), backchannel_opts={
-                        "port": settings().get("clojure").get("backchannel").get("port")
+                        "port": settings().get("clojure").get("backchannel").get("port"),
+                        "bind_address": settings().get("clojure").get("backchannel").get("bind_address", "localhost")
                     }
                 )
 

--- a/src/repl/client.py
+++ b/src/repl/client.py
@@ -211,7 +211,8 @@ class JVMClient(Client):
             self.buffer.readline()
 
         backchannel_port = self.backchannel_opts.get("port", 0)
-        self.write_line(f"""(try (tutkain.repl/repl {{:port {backchannel_port}}}) (catch Exception ex {{:tag :err :val (.toString ex)}}))""")
+        backchannel_bind_address = self.backchannel_opts.get("bind_address", "localhost")
+        self.write_line(f"""(try (tutkain.repl/repl {{:port {backchannel_port} :bind-address "{backchannel_bind_address}"}}) (catch Exception ex {{:tag :err :val (.toString ex)}}))""")
         line = self.buffer.readline()
 
         if not line.startswith('{'):


### PR DESCRIPTION
It is useful when you need to bind a specific address on a remote server.