### PR TITLE
Handle exceptional

### DIFF
--- a/clojure/src/tutkain/test.clj
+++ b/clojure/src/tutkain/test.clj
@@ -61,7 +61,7 @@
     (run! (fn [[sym _]] (ns-unmap ns sym)))))
 
 (defmethod handle :test
-  [{:keys [ns code file vars] :as message}]
+  [{:keys [ns code file vars handle-exception] :as message}]
   (let [filename (some-> file File. .getName)
         ns-sym (or (some-> ns symbol) 'user)]
     (try
@@ -111,4 +111,9 @@
         (respond-to message {:tag :ret
                              :ns (str (.name *ns*))
                              :val (pp-str (assoc (Throwable->map ex) :phase :execution))
-                             :exception true})))))
+                             :exception true
+                             
+                             ;; True if the client wants to handle the exception.
+                             ;; The client doesn't handle exceptions by default,
+                             ;; but the client can explicitly request to do so.
+                             :handle-exception (boolean handle-exception)})))))

--- a/clojure/src/tutkain/test.clj
+++ b/clojure/src/tutkain/test.clj
@@ -61,7 +61,7 @@
     (run! (fn [[sym _]] (ns-unmap ns sym)))))
 
 (defmethod handle :test
-  [{:keys [ns code file vars handle-exception] :as message}]
+  [{:keys [ns code file vars] :as message}]
   (let [filename (some-> file File. .getName)
         ns-sym (or (some-> ns symbol) 'user)]
     (try
@@ -111,9 +111,4 @@
         (respond-to message {:tag :ret
                              :ns (str (.name *ns*))
                              :val (pp-str (assoc (Throwable->map ex) :phase :execution))
-                             :exception true
-                             
-                             ;; True if the client wants to handle the exception.
-                             ;; The client doesn't handle exceptions by default,
-                             ;; but the client can explicitly request to do so.
-                             :handle-exception (boolean handle-exception)})))))
+                             :exception true})))))

--- a/src/repl/backchannel.py
+++ b/src/repl/backchannel.py
@@ -68,8 +68,6 @@ class Backchannel(object):
 
     def handle(self, response):
         try:
-            print(response.get(edn.Keyword("handle-exception")))
-
             if not isinstance(response, dict):
                 self.client.recvq.put(response)
             # It's an exception but the client doesn't want to handle it.

--- a/src/repl/backchannel.py
+++ b/src/repl/backchannel.py
@@ -68,10 +68,13 @@ class Backchannel(object):
 
     def handle(self, response):
         try:
+            print(response.get(edn.Keyword("handle-exception")))
+
             if not isinstance(response, dict):
                 self.client.recvq.put(response)
-            # elif response.get(edn.Keyword("exception")):
-            #     self.client.recvq.put(response)
+            # It's an exception but the client doesn't want to handle it.
+            elif response.get(edn.Keyword("exception")) and not response.get(edn.Keyword("handle-exception")):
+                self.client.recvq.put(response)
             elif response.get(edn.Keyword("debug")):
                 log.debug({"event": "info", "message": response.get(edn.Keyword("val"))})
             else:

--- a/src/repl/backchannel.py
+++ b/src/repl/backchannel.py
@@ -70,16 +70,13 @@ class Backchannel(object):
         try:
             if not isinstance(response, dict):
                 self.client.recvq.put(response)
-            # It's an exception but the client doesn't want to handle it.
-            elif response.get(edn.Keyword("exception")) and not response.get(edn.Keyword("handle-exception")):
-                self.client.recvq.put(response)
             elif response.get(edn.Keyword("debug")):
                 log.debug({"event": "info", "message": response.get(edn.Keyword("val"))})
             else:
                 id = response.get(edn.Keyword("id"))
 
                 try:
-                    handler = self.handlers.get(id)
+                    handler = self.handlers.get(id, self.client.recvq.put)
                     handler.__call__(response)
                 finally:
                     self.handlers.pop(id, None)

--- a/src/repl/backchannel.py
+++ b/src/repl/backchannel.py
@@ -70,8 +70,8 @@ class Backchannel(object):
         try:
             if not isinstance(response, dict):
                 self.client.recvq.put(response)
-            elif response.get(edn.Keyword("exception")):
-                self.client.recvq.put(response)
+            # elif response.get(edn.Keyword("exception")):
+            #     self.client.recvq.put(response)
             elif response.get(edn.Keyword("debug")):
                 log.debug({"event": "info", "message": response.get(edn.Keyword("val"))})
             else:

--- a/src/test.py
+++ b/src/test.py
@@ -228,7 +228,11 @@ def run_tests(view, client, test_vars):
         "ns": namespace.name(view),
         "code": base64.encode(code.encode("utf-8")),
         "file": view.file_name(),
-        "vars": test_vars
+        "vars": test_vars,
+        
+        # We want to handle the exception because 
+        # the handler must be called to stop the progress bar.
+        "handle-exception": True
     }, handler=handler)
 
 

--- a/src/test.py
+++ b/src/test.py
@@ -205,13 +205,20 @@ def add_markers(view, results):
 def run_tests(view, client, test_vars):
     def handler(response):
         view.run_command("tutkain_clear_test_markers")
-        results = response_results(view, response)
 
-        # Persist results so it's possible to create UIs to present it later.
-        view.settings().set(RESULTS_SETTINGS_KEY, serializable_results(results))
+        if not response.get(edn.Keyword("exception")):
+            results = response_results(view, response)
 
-        add_markers(view, results)
+            # Persist results so it's possible to create UIs to present it later.
+            view.settings().set(RESULTS_SETTINGS_KEY, serializable_results(results))
+
+            add_markers(view, results)
+
+        # Put response in the queue and stop progress bar 
+        # regardless of it being exceptional or not:
+
         client.recvq.put(response)
+
         progress.stop()
 
     code = view.substr(sublime.Region(0, view.size()))

--- a/src/test.py
+++ b/src/test.py
@@ -228,11 +228,7 @@ def run_tests(view, client, test_vars):
         "ns": namespace.name(view),
         "code": base64.encode(code.encode("utf-8")),
         "file": view.file_name(),
-        "vars": test_vars,
-        
-        # We want to handle the exception because 
-        # the handler must be called to stop the progress bar.
-        "handle-exception": True
+        "vars": test_vars
     }, handler=handler)
 
 


### PR DESCRIPTION
An idea about letting the client explicitly request to handle the exception.

By default, the handler is not called if a response has an exception, but there are cases where the handler must be called regardless of the response having an exception.

It would be a breaking change to change the backchannel to start calling the handler with exceptions, so instead, we let the client request if it wants to handle the exception. This shouldn't change anything for existing ops.